### PR TITLE
Added 2 Inspectors

### DIFF
--- a/Inspectors/Inspect-SSPRAllowsEmailAuth.json
+++ b/Inspectors/Inspect-SSPRAllowsEmailAuth.json
@@ -1,0 +1,21 @@
+{
+    "FindingName": "SSPR Allows Email Authentication",
+    "Description": "SSPR allows users to reset their password by authenticating with a registered MFA method. SSPR allows Email OTP as an MFA method by default. Note: Email OTP is only available in SSPR and does not satisfy MFA requirements outside of SSPR, reguardless of Tenant configuration.",
+    "Remediation": "Disable Email OTP as an MFA option in the tenat configuration.",
+    "DefaultValue": "Email OTP Enabled",
+    "ExpectedValue": "Null",
+    "Impact": "information",
+    "AffectedObjects": "",
+    "Service": "AzureAD",
+    "PowerShell": "",
+    "References": [
+        {
+            "Url": "https://portal.azure.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods",
+            "Text": "Entra ID Authentication Methods Policy Portal"
+        },
+        {
+            "Url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods-manage",
+            "Text": "Manage authentication methods for Microsoft Entra ID"
+        }
+    ]
+}

--- a/Inspectors/Inspect-SSPRAllowsEmailAuth.ps1
+++ b/Inspectors/Inspect-SSPRAllowsEmailAuth.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+
+$errorHandling = "$((Get-Item $PSScriptRoot).Parent.FullName)\Write-ErrorLog.ps1"
+
+. $errorHandling
+
+
+function Inspect-SSPRAllowsEmailAuth {
+    Try {
+
+        $emailPolicy = (Get-MgPolicyAuthenticationMethodPolicy).AuthenticationMethodConfigurations | Where-Object Id -eq "email"
+
+        if ($emailPolicy.State -eq "disabled") {
+            Return $null
+        }
+
+        $users = Get-MgReportAuthenticationMethodUserRegistrationDetail | Where-Object MethodsRegistered -eq "email"
+
+        $results = @()
+
+        Foreach ($result in $users){
+            $results += "User: $($result.UserDisplayName), UserPrincipalName: $($result.UserPrincipalName), IsAdmin: $($user.IsAdmin)"
+        }
+
+        Return $results
+    }
+    Catch {
+        Write-Warning "Error message: $_"
+        $message = $_.ToString()
+        $exception = $_.Exception
+        $strace = $_.ScriptStackTrace
+        $failingline = $_.InvocationInfo.Line
+        $positionmsg = $_.InvocationInfo.PositionMessage
+        $pscommandpath = $_.InvocationInfo.PSCommandPath
+        $failinglinenumber = $_.InvocationInfo.ScriptLineNumber
+        $scriptname = $_.InvocationInfo.ScriptName
+        Write-Verbose "Write to log"
+        Write-ErrorLog -message $message -exception $exception -scriptname $scriptname
+        Write-Verbose "Errors written to log"
+    }
+}
+
+return Inspect-SSPRAllowsEmailAuth

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://github.com/soteria-security/365Inspect/assets/88730003/af894eb2-7ed8-4082-a51c-dd2da0663ed3" align=right></br></br></br></br>
+
 # Purpose
 
 Further the state of Microsoft 365 security by authoring a PowerShell script that automates the security assessment of Microsoft 365 environments.


### PR DESCRIPTION
Inspect-OAUTHUserConsent:
Checks whether the default user has permissions associated with the ability to consent to OAUTH apps.

Learn Article: https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent?pivots=portal

It appears that the inspector ThirdPartyIntegratedAppPermission is similar, however it only checks if the admin workflow is enabled and if users care able to create apps. This is a separate check that addresses the permission that is assigned to users that allows them to consent at all.

Inspect-CAPolicies_legacyauth:
This inspector checks if there is a CAP that blocks legacy authentication. This is a separate check from if SharePoint allows legacy authentication. 

Code and findings file is copied and refactored from the other CAPolicy-xxx inspectors.

Learn Article: https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy

